### PR TITLE
Add ClockAlignedDataInterval configuration key

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -317,6 +317,11 @@ export const defaultVariableConfig16: Variable16[] = [
     value: true,
   },
   {
+    key: 'ClockAlignedDataInterval',
+    description: 'Size of the clock aligned interval for meter values',
+    value: 0,
+  },
+  {
     key: 'PaymentCurrency',
     description: 'Currency that payments should be made in',
     value: 'EUR',


### PR DESCRIPTION
Not implementing any behaviour around it, for now at least - just supporting the config key. Equivalent OCPP 2 key is already covered.