### PR TITLE
Add unlock connector handlers

### DIFF
--- a/src/lib/ChargeStation/configurations/default-ocpp-16.ts
+++ b/src/lib/ChargeStation/configurations/default-ocpp-16.ts
@@ -29,6 +29,7 @@ import handleReset from '../eventHandlers/ocpp-16/handle-reset';
 import handleSetChargingProfile from '../eventHandlers/ocpp-16/handle-set-charging-profile';
 import handleAuthorizeCallResultReceived from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-authorize-call-result-received';
 import handleDataTransfer from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-data-transfer';
+import handleUnlockConnector from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector';
 import handleGetInstalledCertificateIds from 'lib/ChargeStation/eventHandlers/ocpp-16/handle-get-installed-certificate-ids';
 import handleUpdateFirmwareReceived from '../eventHandlers/ocpp-16/handle-update-firmware-received';
 import handleSignedUpdateFirmwareReceived from '../eventHandlers/ocpp-16/handle-signed-update-firmware-received';
@@ -83,6 +84,7 @@ export default {
   [e.ResetReceived]: [handleReset],
   [e.SetChargingProfileReceived]: [handleSetChargingProfile],
   [e.DataTransferReceived]: [handleDataTransfer],
+  [e.UnlockConnectorReceived]: [handleUnlockConnector],
   [e.GetInstalledCertificatedIdsReceived]: [handleGetInstalledCertificateIds],
   [e.UpdateFirmwareReceived]: [handleUpdateFirmwareReceived],
   [e.TriggerMessageReceived]: [handleTriggerMessageReceived],

--- a/src/lib/ChargeStation/configurations/default-ocpp-20.ts
+++ b/src/lib/ChargeStation/configurations/default-ocpp-20.ts
@@ -30,6 +30,7 @@ import handleGetInstalledCertificateIds from 'lib/ChargeStation/eventHandlers/oc
 import handleUpdateFirmwareReceived from '../eventHandlers/ocpp-20/handle-update-firmware-received';
 import handleTriggerMessageReceived from '../eventHandlers/ocpp-20/handle-trigger-message-received';
 import sendAuthorizeOrStartTransaction from 'lib/ChargeStation/eventHandlers/ocpp-20/send-authorize-or-start-transaction';
+import handleUnlockConnector from 'lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector';
 
 // This is the default configuration for OCPP 2.0.*
 // Each key represents an event, and the value represents an array of handlers that will be called when the event is emitted
@@ -67,6 +68,7 @@ export default {
   [e.ResetReceived]: [handleReset],
   [e.SetChargingProfileReceived]: [handleSetChargingProfile],
   [e.DataTransferReceived]: [handleDataTransfer],
+  [e.UnlockConnectorReceived]: [handleUnlockConnector],
   [e.GetInstalledCertificatedIdsReceived]: [handleGetInstalledCertificateIds],
   [e.UpdateFirmwareReceived]: [handleUpdateFirmwareReceived],
   [e.TriggerMessageReceived]: [handleTriggerMessageReceived],

--- a/src/lib/ChargeStation/eventHandlers/event-types.js
+++ b/src/lib/ChargeStation/eventHandlers/event-types.js
@@ -23,6 +23,7 @@ export const EventTypes = {
   SetChargingProfileReceived: 'setChargingProfileReceived',
   DataTransferReceived: 'dataTransferReceived',
   DataTransferCallResultReceived: 'dataTransferCallResultReceived',
+  UnlockConnectorReceived: 'unlockConnectorReceived',
   GetInstalledCertificatedIdsReceived: 'getInstalledCertificateIdsReceived',
   UpdateFirmwareReceived: 'updateFirmwareReceived',
   TriggerMessageReceived: 'triggerMessageReceived',

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector.ts
@@ -1,0 +1,27 @@
+import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
+import { UnlockConnectorResponse } from 'schemas/ocpp/1.6/UnlockConnectorResponse';
+import { UnlockConnectorRequest } from 'schemas/ocpp/1.6/UnlockConnector';
+
+const handleUnlockConnector: ChargeStationEventHandler<
+  UnlockConnectorRequest
+> = async ({ chargepoint, callMessageBody, callMessageId }) => {
+  // connectorId 0 is not a valid connectorId
+  if (!callMessageBody.connectorId) {
+    const result: UnlockConnectorResponse = {
+      status: 'UnlockFailed',
+    };
+    chargepoint.writeCallResult(callMessageId, result);
+  }
+
+  if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
+    await chargepoint.stopSession(callMessageBody.connectorId);
+  }
+
+  const response: UnlockConnectorResponse = {
+    status: 'Unlocked',
+  };
+
+  chargepoint.writeCallResult(callMessageId, response);
+};
+
+export default handleUnlockConnector;

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector.ts
@@ -13,13 +13,15 @@ const handleUnlockConnector: ChargeStationEventHandler<
     chargepoint.writeCallResult(callMessageId, result);
   }
 
-  if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
-    await chargepoint.stopSession(callMessageBody.connectorId);
-  }
-
   const response: UnlockConnectorResponse = {
     status: 'Unlocked',
   };
+
+  if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
+    await chargepoint.stopSession(callMessageBody.connectorId);
+  } else {
+    response.status = 'UnlockFailed';
+  }
 
   chargepoint.writeCallResult(callMessageId, response);
 };

--- a/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-16/handle-unlock-connector.ts
@@ -14,13 +14,12 @@ const handleUnlockConnector: ChargeStationEventHandler<
   }
 
   const response: UnlockConnectorResponse = {
-    status: 'Unlocked',
+    status: 'UnlockFailed',
   };
 
   if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
     await chargepoint.stopSession(callMessageBody.connectorId);
-  } else {
-    response.status = 'UnlockFailed';
+    response.status = 'Unlocked';
   }
 
   chargepoint.writeCallResult(callMessageId, response);

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector.ts
@@ -1,0 +1,29 @@
+import { ChargeStationEventHandler } from 'lib/ChargeStation/eventHandlers';
+import { UnlockConnectorResponse } from 'schemas/ocpp/2.0/UnlockConnectorResponse';
+import { UnlockConnectorRequest } from 'schemas/ocpp/2.0/UnlockConnectorRequest';
+
+const handleUnlockConnector: ChargeStationEventHandler<
+  UnlockConnectorRequest
+> = async ({ chargepoint, callMessageBody, callMessageId }) => {
+  // connectorId 0 is not a valid connectorId
+  // Currently, the simulator doesn't have a concept of evse's yet, so we ignore the supplied evseId
+  if (!callMessageBody.connectorId) {
+    const result: UnlockConnectorResponse = {
+      status: 'UnknownConnector',
+    };
+    chargepoint.writeCallResult(callMessageId, result);
+  }
+
+  const response: UnlockConnectorResponse = {
+    status: 'Unlocked',
+  };
+  if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
+    await chargepoint.stopSession(callMessageBody.connectorId);
+  } else {
+    response.status = 'UnlockFailed';
+  }
+
+  chargepoint.writeCallResult(callMessageId, response);
+};
+
+export default handleUnlockConnector;

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector.ts
@@ -15,13 +15,12 @@ const handleUnlockConnector: ChargeStationEventHandler<
   }
 
   const response: UnlockConnectorResponse = {
-    status: 'Unlocked',
+    status: 'UnlockFailed',
   };
 
   if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
     await chargepoint.stopSession(callMessageBody.connectorId);
-  } else {
-    response.status = 'UnlockFailed';
+    response.status = 'Unlocked';
   }
 
   chargepoint.writeCallResult(callMessageId, response);

--- a/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector.ts
+++ b/src/lib/ChargeStation/eventHandlers/ocpp-20/handle-unlock-connector.ts
@@ -17,6 +17,7 @@ const handleUnlockConnector: ChargeStationEventHandler<
   const response: UnlockConnectorResponse = {
     status: 'Unlocked',
   };
+
   if (chargepoint.hasRunningSession(callMessageBody.connectorId)) {
     await chargepoint.stopSession(callMessageBody.connectorId);
   } else {


### PR DESCRIPTION
The original implementation for 1.6 was removed because of an accidental force push.
This PR adds the 1.6 and 2.0 implementation